### PR TITLE
added catch for duplicate payrates in Intacct error

### DIFF
--- a/src/target_intacct/client.py
+++ b/src/target_intacct/client.py
@@ -24,6 +24,7 @@ from target_intacct.exceptions import (
 )
 
 from .const import INTACCT_OBJECTS
+logger = singer.get_logger()
 
 class SageIntacctSDK:
     """The base class for all API classes."""
@@ -172,6 +173,10 @@ class SageIntacctSDK:
 
         if response.status_code == 500:
             raise InternalServerError("Internal server error", parsed_response)
+
+        if str(parsed_response).find("BL34000061") != 1:
+            logger.info(f"Payrate Entry {dict_body['request']['operation']['content']} already exists in Intacct for that user and date. Skipping over that entry")
+            return {"result": ""}
 
         raise SageIntacctSDKError("Error: {0}".format(parsed_response))
 

--- a/src/target_intacct/client.py
+++ b/src/target_intacct/client.py
@@ -152,7 +152,7 @@ class SageIntacctSDK:
             if api_response["result"]["status"] == "success":
                 return api_response
             
-            if str(parsed_response).find("BL34000061") != 1:
+            if str(parsed_response).find("BL34000061") != -1:
                 logger.info(f"Payrate Entry {dict_body['request']['operation']['content']} already exists in Intacct for that user and date. Skipping over that entry")
                 return {"result": ""}
 

--- a/src/target_intacct/client.py
+++ b/src/target_intacct/client.py
@@ -151,6 +151,10 @@ class SageIntacctSDK:
 
             if api_response["result"]["status"] == "success":
                 return api_response
+            
+            if str(parsed_response).find("BL34000061") != 1:
+                logger.info(f"Payrate Entry {dict_body['request']['operation']['content']} already exists in Intacct for that user and date. Skipping over that entry")
+                return {"result": ""}
 
         if response.status_code == 400:
             raise WrongParamsError("Some of the parameters are wrong", parsed_response)
@@ -173,10 +177,6 @@ class SageIntacctSDK:
 
         if response.status_code == 500:
             raise InternalServerError("Internal server error", parsed_response)
-
-        if str(parsed_response).find("BL34000061") != 1:
-            logger.info(f"Payrate Entry {dict_body['request']['operation']['content']} already exists in Intacct for that user and date. Skipping over that entry")
-            return {"result": ""}
 
         raise SageIntacctSDKError("Error: {0}".format(parsed_response))
 


### PR DESCRIPTION
When we try to add a payrate to Intacct for a user and date that already exist, Intacct will return the error "BL34000061". This pull request adds functionality to catch that error and simply log that the entry has been skipped over, previously if that occurred the pipeline would fail and no entries would be added. This protects against instances when the previous rows in the Google Sheet may not have been deleted since the last pipeline run. 

**Example Output**
![image](https://github.com/FreshConsulting/target-intacct/assets/129103234/832e4c61-d039-4734-829b-898a12cab48c)
