### PR TITLE
updated the payment amount for manual payments to be positive

### DIFF
--- a/src/target_intacct/payment_record.py
+++ b/src/target_intacct/payment_record.py
@@ -178,5 +178,5 @@ def payment_record_upload(intacct_client, config) -> None:
                     "checkdate": get_date_lines(year, month, day),
                     "checkno": config["checkno"],
                     "billno": config["billno"],
-                    "payitems": {"payitem": {"glaccountno": config["accountno_1"], "paymentamount": payout_amount/100, "item1099": config["item1099"], "departmentid": config["departmentid"], "locationid": config["locationid"]}}}           
+                    "payitems": {"payitem": {"glaccountno": config["accountno_1"], "paymentamount": abs(payout_amount)/100, "item1099": config["item1099"], "departmentid": config["departmentid"], "locationid": config["locationid"]}}}           
             intacct_client.post_manual_payment(data)


### PR DESCRIPTION
Wrapped the payout_amount for manual payments in the abs() function to change it from negative to positive.

When the amount of a Stripe transaction is negative (for example it was a refund) we create a record in the manual payments section of Intacct. The amount in the manual payment should be a positive number reflecting the amount that was payed out. 