### PR TITLE
Updated to No Input Check for Pay Records to Send a Warning Instead of Exception

### DIFF
--- a/src/target_intacct/payment_record.py
+++ b/src/target_intacct/payment_record.py
@@ -137,7 +137,8 @@ def payment_record_upload(intacct_client, config) -> None:
     input_value = get_input()
     
     if not input_value or not isinstance(input_value, list):
-        raise Exception(f"Invalid input data recieved. Input data={input_value}")
+        logger.warning(f"Invalid input data recieved. Stopping pipeline. Input data={input_value}")
+        exit()
     
     # Convert input from dictionary to DataFrames
     payouts, transactions = process_input(input_value) 

--- a/src/target_intacct/payment_record.py
+++ b/src/target_intacct/payment_record.py
@@ -138,7 +138,7 @@ def payment_record_upload(intacct_client, config) -> None:
     
     if not input_value or not isinstance(input_value, list):
         logger.warning(f"Invalid input data recieved. Stopping pipeline. Input data={input_value}")
-        exit()
+        return
     
     # Convert input from dictionary to DataFrames
     payouts, transactions = process_input(input_value) 


### PR DESCRIPTION
In the case of pay records (the input check was not updated for the other object types) there are instances where we will expect no new records to be sent through the pipeline. Since that's the expected functionality we don't want the pipeline to fail, we instead want to log that it occurred 

**Ticket:** https://app.asana.com/0/1200418423170087/1207714252574049